### PR TITLE
refactor: Migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 CHANGELOG.md
 
+## 0.2.0 2021-03-10
+
+- Migrate to null safety
+
 ## 0.1.2 2020-05-20
 
 - Update README to point to pub.dev for example

--- a/lib/src/lat_lng_to_timezone.dart
+++ b/lib/src/lat_lng_to_timezone.dart
@@ -13389,11 +13389,9 @@ int _call46(num lat, num lng) {
 }
 
 class _TzPolygon {
-  List<num> pts;
+  final List<num> pts;
 
-  _TzPolygon(List<num> D) {
-    pts = D;
-  }
+  _TzPolygon(this.pts);
 
   bool contains(num testy, num testx) {
     bool inside = false;
@@ -119615,7 +119613,7 @@ class _Initializer31 {
 }
 
 List<_TzPolygon> initPolyArray() {
-  poly = List<_TzPolygon>(3053);
+  poly = List<_TzPolygon>.filled(3053, _TzPolygon([]));
 
   _Initializer1._init();
   _Initializer2._init();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lat_lng_to_timezone
 description: "Lat/long to timezone mapper in Dart. Does not require web services or data files"
-version: 0.1.2
+version: 0.2.0
 homepage: https://github.com/shawnlauzon/latLngToTimezone
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Dart 2.12 and Flutter 2.0 released. Now every package should be migrated to null safety.

[Sound null safety](https://dart.dev/null-safety)
[Migrating to null safety](https://dart.dev/null-safety/migration-guide)