### PR TITLE
provide timezone names

### DIFF
--- a/lib/src/lat_lng_to_timezone.dart
+++ b/lib/src/lat_lng_to_timezone.dart
@@ -11,6 +11,10 @@ String latLngToTimezoneString(num lat, num lng) {
   return tzId;
 }
 
+// Provides the complete list of timezone names
+// used by this library
+List<String> listTimezoneNames() => _timezoneStrings.toList(growable: false);
+
 List<String> _timezoneStrings = [
   "unknown",
   "Africa/Abidjan",


### PR DESCRIPTION
Provide timezone names known to this
library. This is useful for testing,
e.g. that the list of names used by
this library are compatible with other
libraries.